### PR TITLE
Small improvements.

### DIFF
--- a/js/rwd-display.js
+++ b/js/rwd-display.js
@@ -7,6 +7,7 @@ var viewport = $('meta[name="viewport"]');
 localStorage.isResponsive = (localStorage.isResponsive == undefined) ? 'true' : localStorage.isResponsive;
 
 var showFullSite = function(){    
+    localStorage.responsiveViewportValue = viewport.attr('content');
     viewport.attr('content', 'width=' + targetWidth);  
     
     if(!$('.rwd-display-options #view-responsive').length){
@@ -18,7 +19,7 @@ var showFullSite = function(){
 
 var showMobileOptimized = function(){
     localStorage.isResponsive = 'true';
-    viewport.attr('content', 'width=' + deviceWidth);
+    viewport.attr('content', localStorage.responsiveViewportValue);
 }
 
 // if the user previously chose to view full site, change the viewport

--- a/js/rwd-display.js
+++ b/js/rwd-display.js
@@ -1,38 +1,40 @@
-// viewport stuff
-var targetWidth = 980;
-var deviceWidth = 'device-width';
-var viewport = $('meta[name="viewport"]');
+(function() {
+    // viewport stuff
+    var targetWidth = 980;
+    var deviceWidth = 'device-width';
+    var viewport = $('meta[name="viewport"]');
 
-// check to see if local storage value is set on page load
-localStorage.isResponsive = (localStorage.isResponsive == undefined) ? 'true' : localStorage.isResponsive;
+    // check to see if local storage value is set on page load
+    localStorage.isResponsive = (localStorage.isResponsive == undefined) ? 'true' : localStorage.isResponsive;
 
-var showFullSite = function(){    
-    localStorage.responsiveViewportValue = viewport.attr('content');
-    viewport.attr('content', 'width=' + targetWidth);  
-    
-    if(!$('.rwd-display-options #view-responsive').length){
-        $('.rwd-display-options').append('<span id="view-responsive">View Mobile Optimized</span>');
-    }    
-    
-    localStorage.isResponsive = 'false';
-}
-
-var showMobileOptimized = function(){
-    localStorage.isResponsive = 'true';
-    viewport.attr('content', localStorage.responsiveViewportValue);
-}
-
-// if the user previously chose to view full site, change the viewport
-if(Modernizr.localstorage){
-    if(localStorage.isResponsive == 'false'){
-        showFullSite();
+    var showFullSite = function(){    
+        localStorage.responsiveViewportValue = viewport.attr('content');
+        viewport.attr('content', 'width=' + targetWidth);  
+        
+        if(!$('.rwd-display-options #view-responsive').length){
+            $('.rwd-display-options').append('<span id="view-responsive">View Mobile Optimized</span>');
+        }    
+        
+        localStorage.isResponsive = 'false';
     }
-}    
 
-$("#view-full").on("click", function(){
-    showFullSite();
-});
+    var showMobileOptimized = function(){
+        localStorage.isResponsive = 'true';
+        viewport.attr('content', localStorage.responsiveViewportValue);
+    }
 
-$('.rwd-display-options').on("click", "#view-responsive", function(){
-    showMobileOptimized();
-});
+    // if the user previously chose to view full site, change the viewport
+    if(Modernizr.localstorage){
+        if(localStorage.isResponsive == 'false'){
+            showFullSite();
+        }
+    }    
+
+    $("#view-full").on("click", function(){
+        showFullSite();
+    });
+
+    $('.rwd-display-options').on("click", "#view-responsive", function(){
+        showMobileOptimized();
+    });
+})(jQuery);


### PR DESCRIPTION
I'm not sure if you're still working on this plugin, but this is a small improvement that I've found useful for my sites, when setting more than just the width on the viewport meta.
It just backups the original value from the html for being used when going back to the responsive version. And I wrapped all the code inside an anonymous function because we don't need these variables to be public.

Hope it helps,
thanks!
